### PR TITLE
Fixed installer's Makefile to properly create a cross-compiled executable

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -3,6 +3,8 @@ all: iquik
 COPTS = -O -Wall -Werror
 CFLAGS = -I../include $(COPTS)
 
+CC = $(CROSS)gcc
+
 iquik: iquik.c
 	$(CC) $(CFLAGS) -o iquik iquik.c
 


### PR DESCRIPTION
Currently, all files in loader/ are compiled using the `CROSS` specified tool-chain, but the end installer executable gets compiled using the compiler set in the `CC` environment variable. 

This change fixes that, using the `CROSS` tool-chain for the final output as well. 